### PR TITLE
add feature to disable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ npm start
 
 To run the connector in HTTPS, set the `CERTIFICATE_KEY_FILE` and `CERTIFICATE_CRT_FILE` to the path of the desired plain text certificate and key files.
 
+To disable HTTP, set the environment variable `HTTPS_ONLY`. If `HTTPS_ONLY` is set, then CERTIFICATE_KEY_FILE and CERTIFICATE_CRT_FILE must also be set. Otherwise, starting the server will print a message and exit.
+
 ### Hosted Connector for Primo VE (Deprecated)
 There is a community-supported hosted version of the connector which removes the need to deploy the connector to your own environment. To use the connector, install the [TouchNet Payment Helper Cloud App](https://developers.exlibrisgroup.com/appcenter/touchnet-payment-helper/), click the configuration menu, and enable the hosted connector. You need to supply an API key as described above.
 

--- a/app/index.js
+++ b/app/index.js
@@ -17,6 +17,14 @@ if (process.env.CERTIFICATE_KEY_FILE) {
   credentials = {key: privateKey, cert: certificate};
 }
 
+const HTTPS_ONLY = !!process.env.HTTPS_ONLY;
+if (HTTPS_ONLY && !credentials) {
+  console.error('HTTPS_ONLY is set but no certificate files are provided. Exiting.');
+  process.exit(1);
+}
+
+console.log('Starting Touchnet connector');
+
 let touchnet;
 const init = async (touchnet_ws_url) => {
   if (!touchnet) {
@@ -139,8 +147,7 @@ app.get('/touchnet/error', (request, response) => {
   response.status(400).send('An error has occurred');
 })
 
-// app.listen(PORT);
-http.createServer(app).listen(PORT);
+if (!HTTPS_ONLY) http.createServer(app).listen(PORT);
 if (credentials) https.createServer(credentials, app).listen(SECURE_PORT);
 
 module.exports = { get, success };


### PR DESCRIPTION
Set the environment variable HTTPS_ONLY to any value to skip the HTTP server and only run the HTTPS server. If HTTPS_ONLY is specified, then CERTIFICATE_KEY_FILE and CERTIFICATE_CRT_FILE must also be set. Otherwise, starting the server will print a message and exit.