### PR TITLE
remove no-op Math.floor() invocation

### DIFF
--- a/app/touchnet.js
+++ b/app/touchnet.js
@@ -128,5 +128,5 @@ const getSingleNode = (path, doc) => {
 const cacheBust = uri => {
   if (!uri) return '';
   let param = uri.indexOf('?') == -1 ? '?' : '';
-  return uri + param + '&rand=' + Math.floor(Math.random() * Math.floor(1000000));
+  return uri + param + '&rand=' + Math.floor(Math.random() * 1000000);
 }


### PR DESCRIPTION
Calling Math.floor() on an integer will always return the integer.