### PR TITLE
check that provided returnUrl is a string

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -48,6 +48,10 @@ app.get('/touchnet', async (request, response) => {
   const returnUrl = (protocol + '://' + host + request.originalUrl.split("?").shift()).replace(/\/$/, "");;
   const referrer = request.query.returnUrl || request.header('Referer');
 
+  if (referrer && typeof referrer !== 'string') {
+    return response.status(400).send('Malformed returnUrl');
+  }
+
   try {
     const resp = await get(request.query, returnUrl, referrer);
     response.send(resp);


### PR DESCRIPTION
(Last one for today, I promise.)

If someone (who is in possession of a valid user ID that has fees to pay) is playing games and sends a query string where `returnUrl` is set to an array rather than a string, and that array has a key such as `indexOf` (for example, `/touchnet?returnUrl[indexOf]=foo`), it will cause an error in `generateTicketBody()`. "Error in setting up payment: uri.indexOf is not a function" will be logged and the attacker/user will get "Cannot prepare payment information" in their browser.

This is, of course, an edge case and not that big a deal I suppose, but to make the source code easier to understand (and to prevent anyone from spending time chasing down whether this might or might not be a security vulnerability- almost certainly not, but why even leave the slightest opening?), confirm immediately that `returnUrl` is a string. If it is not, don't bother querying Primo/Alma and trying to set up a ticket in TouchNet.