### PR TITLE
escape HTML before sending error message

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const jwt     = require('jsonwebtoken');
+const escapeHtml = require('escape-html');
 const TouchnetWS = require('./touchnet');
 const responses = require('./responses');
 const dom = require('@xmldom/xmldom').DOMParser;
@@ -54,9 +55,9 @@ app.get('/touchnet', async (request, response) => {
 
   try {
     const resp = await get(request.query, returnUrl, referrer);
-    response.send(resp);
+    response.send(escapeHtml(resp));
   } catch (e) {
-    return response.status(400).send(e.message);
+    return response.status(400).send(escapeHtml(e.message));
   }
 })
 
@@ -115,9 +116,9 @@ const get = async (qs, returnUrl, referrer) => {
 app.post('/touchnet/success', async (request, response) => {
   try {
     const resp = await success(request.body);
-    response.send(resp);
+    response.send(escapeHtml(resp));
   } catch(e) {
-    return response.status(400).send(e.message);
+    return response.status(400).send(escapeHtml(e.message));
   }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@xmldom/xmldom": "^0.7.0",
         "almarestapi-lib": "^1.1.9",
+        "escape-html": "^1.0.3",
         "express": "^4.17.1",
         "jsonwebtoken": "^8.5.1",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.7.0",
     "almarestapi-lib": "^1.1.9",
+    "escape-html": "^1.0.3",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "request": "^2.88.0",


### PR DESCRIPTION
In theory at least, the error message from a thrown error could contain HTML special characters. Escape them before sending them to the web browser.