### PR TITLE
fix: coerce URI value to a string

### DIFF
--- a/app/touchnet.js
+++ b/app/touchnet.js
@@ -127,6 +127,8 @@ const getSingleNode = (path, doc) => {
 
 const cacheBust = uri => {
   if (!uri) return '';
+  // Coerce to a string, just in case a bug or permissive setting allows a non-string.
+  uri = '' + uri;
   let param = uri.indexOf('?') == -1 ? '?' : '';
   return uri + param + '&rand=' + Math.floor(Math.random() * 1000000);
 }


### PR DESCRIPTION
This isn't strictly necessary, as the code base currently guarantees that the `uri` parameter to `cacheBust()` will be a string. But the code that guarantees it is in a separate file, and it's good to make sure there's a guarantee where the parameter is being used.

This won't fix any bugs, but it has three benefits. First, it will reduce or eliminate the impact of any bugs or misconfigurations that might be introduced in the future. There will now be two lines of defense against a type confusion attack rather than one. Second, this should quell false-positive type confusion warnings from automated code quality checkers. Third, in the absence of TypeScript or other mechanisms to guarantee and/or document argument types, this improves maintainability by making it clear to anyone working with the code in the future that `uri` is definitely going to be a string.

I'm using `'' + uri` over `String(uri)` because the former used to be much significantly more performant. I'm not sure if that's the case anymore, and would certainly be happy to use `new String(uri)` if it is preferred for code readability or other reasons.