### PR TITLE
fix: do not escape the HTML responses before sending to browser

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -55,7 +55,7 @@ app.get('/touchnet', async (request, response) => {
 
   try {
     const resp = await get(request.query, returnUrl, referrer);
-    response.send(escapeHtml(resp));
+    response.send(resp);
   } catch (e) {
     return response.status(400).send(escapeHtml(e.message));
   }
@@ -116,7 +116,7 @@ const get = async (qs, returnUrl, referrer) => {
 app.post('/touchnet/success', async (request, response) => {
   try {
     const resp = await success(request.body);
-    response.send(escapeHtml(resp));
+    response.send(resp);
   } catch(e) {
     return response.status(400).send(escapeHtml(e.message));
   }


### PR DESCRIPTION
We want to escape error messages that might contain HTML, but not the actual mostly-hardcoded HTML responses that we intend to send to the user. This fixes the connector, which is currently totally broken. (My fault. Sorry!)