### PR TITLE
fix: use correct ticket name in redirect form

### DIFF
--- a/app/responses.js
+++ b/app/responses.js
@@ -1,9 +1,9 @@
-const redirectForm = (ticket, user_id, upay_site_id, upay_site_url) => {
+const redirectForm = (ticket, ticket_name, upay_site_id, upay_site_url) => {
   return `
     <form method="post" action="${upay_site_url || process.env.UPAY_SITE_URL}" name="touchnet">
       <input type="hidden" name="UPAY_SITE_ID" value="${upay_site_id || process.env.UPAY_SITE_ID}">
       <input type="hidden" name="TICKET" value="${ticket}">
-      <input type="hidden" name="TICKET_NAME" value="${user_id}">
+      <input type="hidden" name="TICKET_NAME" value="${ticket_name}">
     </form>
     Redirecting to payment site.
     <script>

--- a/app/touchnet.js
+++ b/app/touchnet.js
@@ -33,8 +33,8 @@ class TouchnetWS {
     this.auth = data.TOUCHNET_WS_AUTH; 
   }
 
-  async generateTicket(user_id, options ) {
-    let response = await touchnetRequest(this.uri, this.auth, generateTicketBody(user_id, options));
+  async generateTicket(ticketName, options ) {
+    let response = await touchnetRequest(this.uri, this.auth, generateTicketBody(ticketName, options));
     return getSingleNode('/soapenv:Envelope/soapenv:Body/tn:generateSecureLinkTicketResponse/tn:ticket', response);
   }
 
@@ -66,12 +66,7 @@ const touchnetRequest = (uri, auth, xml) => {
   return requestp(options);
 }
 
-const generateTicketBody = (user_id, options) => {
-  let d = new Date,
-    dformat = [d.getFullYear(), d.getMonth()+1, d.getDate()].join('-') + '_' +
-              [d.getHours(), d.getMinutes(), d.getSeconds()].join('');
-  let ticketName = user_id+"_"+dformat;
-  
+const generateTicketBody = (ticketName, options) => {
   return `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typ="http://types.secureLink.touchnet.com">
   <soapenv:Header/>
   <soapenv:Body>


### PR DESCRIPTION
The current code does not work, at least in my environment. TouchNet staff let me know the error on their end, and it was that the ticket name initially sent (which includes a date stamp) was not the ticket name eventually used (which was just the user id without a date stamp). This fixes the issue.